### PR TITLE
Fixing as_string in python3 whith custom headers

### DIFF
--- a/mailer.py
+++ b/mailer.py
@@ -30,6 +30,7 @@ Sample code:
 
 """
 from __future__ import with_statement
+import sys
 import smtplib
 import socket
 import threading
@@ -65,6 +66,7 @@ __version__ = "0.7"
 __author__ = "Ryan Ginstrom"
 __license__ = "MIT"
 __description__ = "A module to send email simply in Python"
+PY3 = sys.version_info >= (3,)
 
 
 class Mailer(object):
@@ -317,7 +319,10 @@ class Message(object):
 
         if self.Headers:
             for key, value in self.Headers.items():
-                msg[key] = str(value).encode(self.charset)
+                if PY3:
+                    msg[key] = value
+                else:
+                    msg[key] = str(value).encode(self.charset)
 
 
         msg['Date'] = self.Date

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,0 +1,21 @@
+import unittest
+
+from email.utils import make_msgid
+
+from mailer import Message
+
+class MessageTestCase(unittest.TestCase):
+    def test_message_as_string(self):
+        msg = Message(
+            To='foo@test.com',
+            From='bar@test.com',
+            Subject='Test Message',
+            Text='This is just a test message.',
+            Html='<body><p>This is just a test message.</p></body>',
+        )
+        msg.header('Message-ID', make_msgid())
+        s = msg.as_string()
+        assert type(s) == str
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
The as_string method was raising an exception (AttributeError: 'bytes'
object has no attribute 'encode') when customer headers are
defined.

Prior to this patch the test_message_as_string test fails
```
======================================================================
ERROR: test_message_as_string (__main__.MessageTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_message.py", line 17, in test_message_as_string
    s = msg.as_string()
  File "/Volumes/datavol/src/python-mailer/build/lib/mailer.py", line 242, in as_string
    return self._plaintext()
  File "/Volumes/datavol/src/python-mailer/build/lib/mailer.py", line 255, in _plaintext
    return msg.as_string()
  File "/usr/local/Cellar/python34/3.4.4_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/email/message.py", line 159, in as_string
    g.flatten(self, unixfrom=unixfrom)
  File "/usr/local/Cellar/python34/3.4.4_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/email/generator.py", line 112, in flatten
    self._write(msg)
  File "/usr/local/Cellar/python34/3.4.4_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/email/generator.py", line 192, in _write
    self._write_headers(msg)
  File "/usr/local/Cellar/python34/3.4.4_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/email/generator.py", line 220, in _write_headers
    self.write(self.policy.fold(h, v))
  File "/usr/local/Cellar/python34/3.4.4_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/email/_policybase.py", line 314, in fold
    return self._fold(name, value, sanitize=True)
  File "/usr/local/Cellar/python34/3.4.4_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/email/_policybase.py", line 352, in _fold
    parts.append(h.encode(linesep=self.linesep,
AttributeError: 'bytes' object has no attribute 'encode'

----------------------------------------------------------------------
Ran 1 test in 0.015s
```